### PR TITLE
Simple entity pathing.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(${CORE_LIB_NAME} STATIC
         components/collider_obb.h
         components/collider_sphere.h
         components/collider_obb.h
+        components/enemy_path_component.h
         cvars/cvars.cpp
         cvars/cvars.h)
 

--- a/core/components/enemy_path_component.h
+++ b/core/components/enemy_path_component.h
@@ -4,10 +4,13 @@
 struct EnemyPath {
 	std::vector<glm::vec3> path;
 	unsigned int next_position = 0;
+	float speed = 1.0f;
 
 	void serialize_json(nlohmann::json &serialized_scene) {
 		nlohmann::json::object_t serialized_component;
 		serialized_scene.push_back(nlohmann::json::object());
+
+		serialized_component["speed"] = speed;
 
 		int i = 0;
 		for (auto &pos : path) {
@@ -25,6 +28,7 @@ struct EnemyPath {
 
 	void deserialize_json(nlohmann::json &serialized_component) {
 		int i = 0;
+		speed = serialized_component["speed"];
 		while (true) {
 			std::string pos_x = "path_" + std::to_string(i) + "_x";
 			std::string pos_y = "path_" + std::to_string(i) + "_y";
@@ -39,6 +43,8 @@ struct EnemyPath {
 
 			i++;
 		}
+
+
 	}
 };
 

--- a/core/components/enemy_path_component.h
+++ b/core/components/enemy_path_component.h
@@ -3,7 +3,7 @@
 
 struct EnemyPath {
 	std::vector<glm::vec3> path;
-	unsigned int next_position = 0;
+	int next_position = 0;
 	float speed = 1.0f;
 	float rotation_speed = 1.0f;
 	glm::vec3 rotation_start = glm::vec3(0.0f);

--- a/core/components/enemy_path_component.h
+++ b/core/components/enemy_path_component.h
@@ -1,0 +1,45 @@
+#ifndef SILENCE_ENEMY_PATH_H
+#define SILENCE_ENEMY_PATH_H
+
+struct EnemyPath {
+	std::vector<glm::vec3> path;
+	unsigned int next_position = 0;
+
+	void serialize_json(nlohmann::json &serialized_scene) {
+		nlohmann::json::object_t serialized_component;
+		serialized_scene.push_back(nlohmann::json::object());
+
+		int i = 0;
+		for (auto &pos : path) {
+
+			serialized_component["path_" + std::to_string(i) + "_x"] = pos.x;
+			serialized_component["path_" + std::to_string(i) + "_y"] = pos.y;
+			serialized_component["path_" + std::to_string(i) + "_z"] = pos.z;
+
+			i++;
+		}
+
+		serialized_scene.back()["component_data"] = serialized_component;
+		serialized_scene.back()["component_name"] = "EnemyPath";
+	}
+
+	void deserialize_json(nlohmann::json &serialized_component) {
+		int i = 0;
+		while (true) {
+			std::string pos_x = "path_" + std::to_string(i) + "_x";
+			std::string pos_y = "path_" + std::to_string(i) + "_y";
+			std::string pos_z = "path_" + std::to_string(i) + "_z";
+
+			if (serialized_component.contains(pos_x) && serialized_component.contains(pos_y) && serialized_component.contains(pos_z)) {
+				path.emplace_back(serialized_component[pos_x], serialized_component[pos_y], serialized_component[pos_z]);
+			}
+			else {
+				break;
+			}
+
+			i++;
+		}
+	}
+};
+
+#endif //SILENCE_ENEMY_PATH_H

--- a/core/components/enemy_path_component.h
+++ b/core/components/enemy_path_component.h
@@ -4,12 +4,13 @@
 struct EnemyPath {
 	std::vector<glm::vec3> path;
 	unsigned int next_position = 0;
-	bool is_looking_at_target = false;
 	float speed = 1.0f;
 	float rotation_speed = 1.0f;
-	float rotation_transition = 0.0f;
 	glm::vec3 rotation_start = glm::vec3(0.0f);
 	glm::vec3 rotation_end = glm::vec3(0.0f);
+	glm::vec3 prev_position = glm::vec3(0.0f);
+	bool is_rotating = false;
+	bool first_rotation_frame = false;
 
 	void serialize_json(nlohmann::json &serialized_scene) {
 		nlohmann::json::object_t serialized_component;

--- a/core/components/enemy_path_component.h
+++ b/core/components/enemy_path_component.h
@@ -4,13 +4,19 @@
 struct EnemyPath {
 	std::vector<glm::vec3> path;
 	unsigned int next_position = 0;
+	bool is_looking_at_target = false;
 	float speed = 1.0f;
+	float rotation_speed = 1.0f;
+	float rotation_transition = 0.0f;
+	glm::vec3 rotation_start = glm::vec3(0.0f);
+	glm::vec3 rotation_end = glm::vec3(0.0f);
 
 	void serialize_json(nlohmann::json &serialized_scene) {
 		nlohmann::json::object_t serialized_component;
 		serialized_scene.push_back(nlohmann::json::object());
 
 		serialized_component["speed"] = speed;
+		serialized_component["rotation_speed"] = rotation_speed;
 
 		int i = 0;
 		for (auto &pos : path) {
@@ -29,6 +35,7 @@ struct EnemyPath {
 	void deserialize_json(nlohmann::json &serialized_component) {
 		int i = 0;
 		speed = serialized_component["speed"];
+		rotation_speed = serialized_component["rotation_speed"];
 		while (true) {
 			std::string pos_x = "path_" + std::to_string(i) + "_x";
 			std::string pos_y = "path_" + std::to_string(i) + "_y";

--- a/core/components/transform_component.h
+++ b/core/components/transform_component.h
@@ -99,7 +99,8 @@ public:
 	}
 
 	[[nodiscard]] glm::vec3 get_forward() const {
-		return glm::normalize(glm::vec3(local_model_matrix[2]));
+		//return glm::normalize(glm::vec3(local_model_matrix[2]));
+		return orientation * glm::vec3(0.0f, 0.0f, 1.0f);
 	}
 	[[nodiscard]] glm::vec3 get_up() const {
 		return glm::normalize(glm::vec3(local_model_matrix[1]));

--- a/core/serialization.h
+++ b/core/serialization.h
@@ -8,6 +8,7 @@
 #include "components/collider_obb.h"
 #include "components/collider_sphere.h"
 #include "components/collider_tag_component.h"
+#include "components/enemy_path_component.h"
 #include "components/fmod_listener_component.h"
 #include "components/light_component.h"
 #include "components/name_component.h"
@@ -33,7 +34,7 @@ concept Deserializable = requires(T t, nlohmann::json &j) {
 };
 
 typedef std::variant<Children, Parent, Transform, RigidBody, FmodListener, Camera, ModelInstance, AnimationInstance,
-		SkinnedModelInstance, Name, ColliderTag, StaticTag, ColliderSphere, ColliderAABB, ColliderOBB, Light, AgentData>
+		SkinnedModelInstance, Name, ColliderTag, StaticTag, ColliderSphere, ColliderAABB, ColliderOBB, Light, AgentData, EnemyPath>
 		variant_type;
 
 template <typename T>

--- a/editor/inspector_gui.cpp
+++ b/editor/inspector_gui.cpp
@@ -602,6 +602,7 @@ void Inspector::show_enemy_path() {
 		ImGui::TableSetupColumn("##Col1", ImGuiTableColumnFlags_WidthFixed, available_width * 0.33f);
 
 		int i = 0;
+		show_float("Speed", enemy_path.speed);
 		for (auto &node : enemy_path.path) {
 			std::string label = fmt::format("Node {}", i++);
 			show_vec3(label.c_str(), node);

--- a/editor/inspector_gui.cpp
+++ b/editor/inspector_gui.cpp
@@ -49,6 +49,7 @@ void Inspector::show_components() {
 	SHOW_COMPONENT(ColliderOBB, show_colliderobb);
 	SHOW_COMPONENT(Light, show_light);
 	SHOW_COMPONENT(AgentData, show_agent_data);
+	SHOW_COMPONENT(EnemyPath, show_enemy_path);
 
 	for (int i = 0; i < remove_component_queue.size(); i++) {
 		auto [entity, component_to_remove] = remove_component_queue.front();
@@ -584,6 +585,31 @@ void Inspector::show_agent_data() {
 	}
 }
 
+void Inspector::show_enemy_path() {
+	auto &enemy_path = world->get_component<EnemyPath>(selected_entity);
+	if (ImGui::CollapsingHeader("Enemy Path", tree_flags)) {
+		if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
+			ImGui::OpenPopup("EnemyPathContextMenu");
+		}
+		if (ImGui::BeginPopup("EnemyPathContextMenu")) {
+			if (ImGui::MenuItem("Add Node")) {
+				enemy_path.path.emplace_back(0.0f);
+			}
+			ImGui::EndPopup();
+		}
+		float available_width = ImGui::GetContentRegionAvail().x;
+		ImGui::BeginTable("Enemy Path", 2);
+		ImGui::TableSetupColumn("##Col1", ImGuiTableColumnFlags_WidthFixed, available_width * 0.33f);
+
+		int i = 0;
+		for (auto &node : enemy_path.path) {
+			std::string label = fmt::format("Node {}", i++);
+			show_vec3(label.c_str(), node);
+		}
+		ImGui::EndTable();
+	}
+}
+
 bool Inspector::show_vec3(
 		const char *label, glm::vec3 &vec3, float speed, float reset_value, float min_value, float max_value) {
 	bool changed = false;
@@ -635,6 +661,15 @@ void Inspector::show_text(const char *label, int value) {
 	std::string value_str = std::to_string(value);
 
 	Inspector::show_text(label, value_str.c_str());
+}
+
+void Inspector::show_vector_vec3(const char *label, std::vector<glm::vec3> &vec3) {
+	ImGui::TableNextRow();
+	ImGui::TableSetColumnIndex(0);
+	ImGui::Text("%s", label);
+	ImGui::TableSetColumnIndex(1);
+	ImGui::SetNextItemWidth(-FLT_MIN);
+	ImGui::Text("%d", vec3.size());
 }
 
 void Inspector::show_add_component() {
@@ -696,6 +731,7 @@ void Inspector::show_add_component() {
 			SHOW_ADD_COMPONENT(ColliderOBB);
 			SHOW_ADD_COMPONENT(Light);
 			SHOW_ADD_COMPONENT(AgentData);
+			SHOW_ADD_COMPONENT(EnemyPath);
 
 			ImGui::EndPopup();
 		}

--- a/editor/inspector_gui.cpp
+++ b/editor/inspector_gui.cpp
@@ -593,7 +593,19 @@ void Inspector::show_enemy_path() {
 		}
 		if (ImGui::BeginPopup("EnemyPathContextMenu")) {
 			if (ImGui::MenuItem("Add Node")) {
-				enemy_path.path.emplace_back(0.0f);
+				if (enemy_path.path.empty()) {
+					// if this is the first node, add it in place of transform
+					auto &transform = world->get_component<Transform>(selected_entity);
+					enemy_path.path.emplace_back(transform.position);
+				} else {
+					// otherwise, add it in place of the last node
+					enemy_path.path.emplace_back(enemy_path.path.back());
+				}
+			}
+			if (ImGui::MenuItem("Remove Node")) {
+				if (!enemy_path.path.empty()) {
+					enemy_path.path.pop_back();
+				}
 			}
 			ImGui::EndPopup();
 		}

--- a/editor/inspector_gui.cpp
+++ b/editor/inspector_gui.cpp
@@ -603,6 +603,7 @@ void Inspector::show_enemy_path() {
 
 		int i = 0;
 		show_float("Speed", enemy_path.speed);
+		show_float("Rot Speed", enemy_path.rotation_speed);
 		for (auto &node : enemy_path.path) {
 			std::string label = fmt::format("Node {}", i++);
 			show_vec3(label.c_str(), node);

--- a/editor/inspector_gui.h
+++ b/editor/inspector_gui.h
@@ -32,11 +32,13 @@ private:
 	void show_colliderobb();
 	void show_light();
 	void show_agent_data();
+	void show_enemy_path();
 	static bool show_vec3(const char *label, glm::vec3 &vec3, float speed = 0.1f, float reset_value = 0.0f,
 			float min_value = 100.0f, float max_value = 100.0f);
 	static bool show_float(const char *label, float &value, float speed = 0.1f);
 	static void show_checkbox(const char *label, bool &value);
 	static void show_text(const char *label, const char *value);
+	static void show_vector_vec3(const char *label, std::vector<glm::vec3> &vec3);
 
 	template <typename T> void remove_component_popup() {
 		std::string popup_name = fmt::format("Remove {}", typeid(T).name());

--- a/engine/scene.cpp
+++ b/engine/scene.cpp
@@ -10,6 +10,8 @@
 #include "ecs/systems/agent_system.h"
 #include "ecs/systems/collider_draw.h"
 #include "ecs/systems/collision_system.h"
+#include "ecs/systems/enemy_path_draw_system.h"
+#include "ecs/systems/enemy_pathing.h"
 #include "ecs/systems/isolated_entities_system.h"
 #include "ecs/systems/light_system.h"
 #include "ecs/systems/physics_system.h"
@@ -44,6 +46,7 @@ Scene::Scene() {
 	world.register_component<ColliderOBB>();
 	world.register_component<Light>();
 	world.register_component<AgentData>();
+	world.register_component<EnemyPath>();
 
 	// Systems
 	// TODO: Set update order instead of using default value
@@ -53,6 +56,7 @@ Scene::Scene() {
 	world.register_system<AnimationSystem>();
 	world.register_system<FrustumDrawSystem>();
 	world.register_system<LightSystem>();
+	world.register_system<EnemyPathDraw>();
 
 	// Transform
 	world.register_system<IsolatedEntitiesSystem>();
@@ -66,6 +70,7 @@ void Scene::register_game_systems() {
 
 	// Agents
 	world.register_system<AgentSystem>();
+	world.register_system<EnemyPathing>();
 }
 
 void Scene::update(float dt) {

--- a/game/main.cpp
+++ b/game/main.cpp
@@ -13,7 +13,7 @@ int main() {
 
 	game.create_scene("Main");
 	game.scenes[0]->register_game_systems();
-	game.scenes[0]->load_from_file("resources/scenes/level_0.scn");
+	game.scenes[0]->load_from_file("resources/scenes/enemy_test.scn");
 	game.set_active_scene("Main");
 
 	game.run();

--- a/game/main.cpp
+++ b/game/main.cpp
@@ -13,7 +13,7 @@ int main() {
 
 	game.create_scene("Main");
 	game.scenes[0]->register_game_systems();
-	game.scenes[0]->load_from_file("resources/scenes/enemy_test.scn");
+	game.scenes[0]->load_from_file("resources/scenes/level_0.scn");
 	game.set_active_scene("Main");
 
 	game.run();

--- a/managers/ecs/CMakeLists.txt
+++ b/managers/ecs/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(${ECS_MANAGER_NAME} STATIC
         systems/collider_draw.cpp systems/collider_draw.h
         systems/light_system.cpp systems/light_system.h
         systems/agent_system.cpp systems/agent_system.h
-        )
+        systems/enemy_pathing.cpp systems/enemy_pathing.h systems/enemy_path_draw_system.cpp systems/enemy_path_draw_system.h)
 
 target_include_directories(${ECS_MANAGER_NAME} PUBLIC ${MANAGER_DIR})
 

--- a/managers/ecs/systems/agent_system.cpp
+++ b/managers/ecs/systems/agent_system.cpp
@@ -33,7 +33,10 @@ void AgentSystem::update(World &world, float dt) {
 		auto &model_tf = world.get_component<Transform>(agent_data.model);
 		auto &camera_tf = world.get_component<Transform>(agent_data.camera);
 
+		auto &dd = world.get_parent_scene()->get_render_scene().debug_draw;
+
 		auto camera_forward = camera_pivot_tf.get_global_forward();
+
 		camera_forward.y = 0.0f;
 		camera_forward = glm::normalize(camera_forward);
 		auto camera_right = camera_pivot_tf.get_global_right();

--- a/managers/ecs/systems/enemy_path_draw_system.cpp
+++ b/managers/ecs/systems/enemy_path_draw_system.cpp
@@ -1,0 +1,29 @@
+#include "enemy_path_draw_system.h"
+#include <components/enemy_path_component.h>
+#include "ecs/world.h"
+#include "engine/scene.h"
+
+void EnemyPathDraw::startup(World &world) {
+	Signature whitelist;
+
+	whitelist.set(world.get_component_type<EnemyPath>());
+
+	world.set_system_component_whitelist<EnemyPathDraw>(whitelist);
+}
+
+void EnemyPathDraw::update(World &world, float dt) {
+	auto &r_s = world.get_parent_scene()->get_render_scene();
+	for (const Entity entity : entities) {
+		auto &enemy_path = world.get_component<EnemyPath>(entity);
+
+		int size = enemy_path.path.size();
+		for (int i = 0; i < size; i++) {
+			r_s.debug_draw.draw_sphere(enemy_path.path[i], 0.2f, glm::vec3(1.0f, 0.0f, 0.0f));
+			r_s.debug_draw.draw_line(
+					enemy_path.path[i],
+					enemy_path.path[(i + 1) % enemy_path.path.size()],
+					glm::vec3(1.0f, 1.0f, 1.0f));
+		}
+
+	}
+}

--- a/managers/ecs/systems/enemy_path_draw_system.h
+++ b/managers/ecs/systems/enemy_path_draw_system.h
@@ -1,0 +1,12 @@
+#ifndef SILENCE_ENEMY_PATH_DRAW_SYSTEM_H
+#define SILENCE_ENEMY_PATH_DRAW_SYSTEM_H
+
+#include "base_system.h"
+
+class EnemyPathDraw : public BaseSystem {
+public:
+	void startup(World &world) override;
+	void update(World &world, float dt) override;
+};
+
+#endif //SILENCE_ENEMY_PATH_DRAW_SYSTEM_H

--- a/managers/ecs/systems/enemy_pathing.cpp
+++ b/managers/ecs/systems/enemy_pathing.cpp
@@ -7,6 +7,7 @@ void EnemyPathing::startup(World &world) {
 	Signature whitelist;
 
 	whitelist.set(world.get_component_type<Transform>());
+	whitelist.set(world.get_component_type<EnemyPath>());
 
 	world.set_system_component_whitelist<EnemyPathing>(whitelist);
 }
@@ -19,6 +20,14 @@ void EnemyPathing::update(World &world, float dt) {
 
 		glm::vec3 current_position = transform.position;
 		glm::vec3 target_position = enemy_path.path[enemy_path.next_position];
+
+		if (glm::distance(current_position, target_position) > 0.1f) {
+			SPDLOG_INFO("Enemy Pathing: {} -> {}", glm::to_string(current_position), glm::to_string(target_position));
+			transform.add_position(glm::normalize(target_position - current_position) * enemy_path.speed * dt);
+
+		} else {
+			enemy_path.next_position = (enemy_path.next_position + 1) % enemy_path.path.size();
+		}
 
 	}
 }

--- a/managers/ecs/systems/enemy_pathing.cpp
+++ b/managers/ecs/systems/enemy_pathing.cpp
@@ -2,6 +2,9 @@
 #include "ecs/world.h"
 #include "engine/scene.h"
 #include <components/enemy_path_component.h>
+#include "glm/gtc/quaternion.hpp"
+
+void look_at(EnemyPath &path, Transform &t, glm::vec3 &target, float &dt, DebugDraw &dd);
 
 void EnemyPathing::startup(World &world) {
 	Signature whitelist;
@@ -20,14 +23,31 @@ void EnemyPathing::update(World &world, float dt) {
 
 		glm::vec3 current_position = transform.position;
 		glm::vec3 target_position = enemy_path.path[enemy_path.next_position];
+		auto &dd = world.get_parent_scene()->get_render_scene().debug_draw;
+
+
 
 		if (glm::distance(current_position, target_position) > 0.1f) {
-			SPDLOG_INFO("Enemy Pathing: {} -> {}", glm::to_string(current_position), glm::to_string(target_position));
 			transform.add_position(glm::normalize(target_position - current_position) * enemy_path.speed * dt);
-
 		} else {
 			enemy_path.next_position = (enemy_path.next_position + 1) % enemy_path.path.size();
+			enemy_path.is_looking_at_target = false;
+			SPDLOG_INFO("NOT LOOKING AT TARGET");
 		}
-
+		look_at(enemy_path, transform, target_position, dt, dd);
+		dd.draw_line(current_position, current_position + glm::normalize(transform.get_global_forward()), glm::vec3(0.0f, 0.0f, 1.0f));
+		dd.draw_line(current_position, current_position + glm::normalize(target_position - transform.position), glm::vec3(1.0f, 0.0f, 0.0f));
 	}
+}
+
+void look_at(EnemyPath &path, Transform &t, glm::vec3 &target, float &dt, DebugDraw &dd) {
+	auto current_no_y = glm::vec3(t.position.x, 0.0f, t.position.z);
+	auto target_no_y = glm::vec3(target.x, 0.0f, target.z);
+
+	glm::vec3 direction = glm::normalize(target_no_y - current_no_y);
+	glm::vec3 forward =
+			glm::normalize(glm::vec3(t.get_global_forward().x, 0.0f, t.get_global_forward().z));
+	float angle = glm::acos(glm::dot(forward, direction)) * dt * path.rotation_speed;
+	glm::vec3 axis = glm::cross(forward, direction);
+	t.add_global_euler_rot(angle * axis);
 }

--- a/managers/ecs/systems/enemy_pathing.cpp
+++ b/managers/ecs/systems/enemy_pathing.cpp
@@ -1,0 +1,24 @@
+#include "enemy_pathing.h"
+#include "ecs/world.h"
+#include "engine/scene.h"
+#include <components/enemy_path_component.h>
+
+void EnemyPathing::startup(World &world) {
+	Signature whitelist;
+
+	whitelist.set(world.get_component_type<Transform>());
+
+	world.set_system_component_whitelist<EnemyPathing>(whitelist);
+}
+
+void EnemyPathing::update(World &world, float dt) {
+	auto r_s = world.get_parent_scene()->get_render_scene();
+	for (const Entity entity : entities) {
+		auto &transform = world.get_component<Transform>(entity);
+		auto &enemy_path = world.get_component<EnemyPath>(entity);
+
+		glm::vec3 current_position = transform.position;
+		glm::vec3 target_position = enemy_path.path[enemy_path.next_position];
+
+	}
+}

--- a/managers/ecs/systems/enemy_pathing.cpp
+++ b/managers/ecs/systems/enemy_pathing.cpp
@@ -23,31 +23,49 @@ void EnemyPathing::update(World &world, float dt) {
 
 		glm::vec3 current_position = transform.position;
 		glm::vec3 target_position = enemy_path.path[enemy_path.next_position];
+		enemy_path.prev_position = enemy_path.path[(enemy_path.next_position - 1) % enemy_path.path.size()];
+
 		auto &dd = world.get_parent_scene()->get_render_scene().debug_draw;
-
-
 
 		if (glm::distance(current_position, target_position) > 0.1f) {
 			transform.add_position(glm::normalize(target_position - current_position) * enemy_path.speed * dt);
 		} else {
 			enemy_path.next_position = (enemy_path.next_position + 1) % enemy_path.path.size();
-			enemy_path.is_looking_at_target = false;
-			SPDLOG_INFO("NOT LOOKING AT TARGET");
 		}
-		look_at(enemy_path, transform, target_position, dt, dd);
+		// this huge if just means "when near a node on either side"
+		if (glm::distance(current_position, target_position) < (glm::distance(enemy_path.prev_position, target_position)) * 0.1f
+				|| glm::distance(current_position, enemy_path.prev_position) < (glm::distance(enemy_path.prev_position, target_position)) * 0.1f) {
+			SPDLOG_INFO("near node");
+			if (!enemy_path.is_rotating) {
+				enemy_path.first_rotation_frame = true;
+			}
+			enemy_path.is_rotating = true;
+		}
+		if (glm::dot(glm::normalize(target_position - transform.position), glm::normalize(transform.get_global_forward())) > 0.999f) {
+			enemy_path.is_rotating = false;
+		}
+		if (enemy_path.is_rotating) {
+			look_at(enemy_path, transform, target_position, dt, dd);
+		}
+
 		dd.draw_line(current_position, current_position + glm::normalize(transform.get_global_forward()), glm::vec3(0.0f, 0.0f, 1.0f));
 		dd.draw_line(current_position, current_position + glm::normalize(target_position - transform.position), glm::vec3(1.0f, 0.0f, 0.0f));
 	}
 }
 
 void look_at(EnemyPath &path, Transform &t, glm::vec3 &target, float &dt, DebugDraw &dd) {
-	auto current_no_y = glm::vec3(t.position.x, 0.0f, t.position.z);
-	auto target_no_y = glm::vec3(target.x, 0.0f, target.z);
+	if (path.first_rotation_frame) {
+		SPDLOG_INFO("calculating rotation");
+		auto current_no_y = glm::vec3(t.position.x, 0.0f, t.position.z);
+		auto target_no_y = glm::vec3(target.x, 0.0f, target.z);
 
-	glm::vec3 direction = glm::normalize(target_no_y - current_no_y);
-	glm::vec3 forward =
-			glm::normalize(glm::vec3(t.get_global_forward().x, 0.0f, t.get_global_forward().z));
-	float angle = glm::acos(glm::dot(forward, direction)) * dt * path.rotation_speed;
-	glm::vec3 axis = glm::cross(forward, direction);
-	t.add_global_euler_rot(angle * axis);
+		glm::vec3 direction = glm::normalize(target_no_y - current_no_y);
+		glm::vec3 forward = glm::normalize(glm::vec3(t.get_global_forward().x, 0.0f, t.get_global_forward().z));
+		float angle = glm::acos(glm::dot(forward, direction));
+		glm::vec3 axis = glm::cross(forward, direction);
+		path.rotation_end = (angle * axis);
+		path.first_rotation_frame = false;
+	}
+	t.add_global_euler_rot(path.rotation_end * dt * path.rotation_speed);
+
 }

--- a/managers/ecs/systems/enemy_pathing.h
+++ b/managers/ecs/systems/enemy_pathing.h
@@ -1,0 +1,12 @@
+#ifndef SILENCE_ENEMY_PATHING_H
+#define SILENCE_ENEMY_PATHING_H
+
+#include "base_system.h"
+
+class EnemyPathing : public BaseSystem {
+public:
+	void startup(World &world) override;
+	void update(World &world, float dt) override;
+};
+
+#endif //SILENCE_ENEMY_PATHING_H

--- a/resources/scenes/level_0.scn
+++ b/resources/scenes/level_0.scn
@@ -190,20 +190,20 @@
             {
                 "component_data": {
                     "orientation": {
-                        "w": 0.9997175335884094,
+                        "w": 0.6371151208877563,
                         "x": 0.0,
-                        "y": 0.023765597492456436,
+                        "y": 0.7707686424255371,
                         "z": 0.0
                     },
                     "position": {
-                        "x": -2.1068503856658936,
-                        "y": 0.999755859375,
-                        "z": 13.183966636657715
+                        "x": -13.192577362060547,
+                        "y": -0.000244140625,
+                        "z": 13.075940132141113
                     },
                     "scale": {
-                        "x": 0.9999998807907104,
+                        "x": 0.9999970197677612,
                         "y": 1.0,
-                        "z": 0.9999998807907104
+                        "z": 0.9999970197677612
                     }
                 },
                 "component_name": "Transform"
@@ -220,10 +220,53 @@
                     "model_name": "agent/agent.skinmdl"
                 },
                 "component_name": "SkinnedModelInstance"
+            },
+            {
+                "component_data": {
+                    "path_0_x": -12.418999671936035,
+                    "path_0_y": 0.0,
+                    "path_0_z": 13.034727096557617,
+                    "path_10_x": -13.819000244140625,
+                    "path_10_y": 0.0,
+                    "path_10_z": 10.53499984741211,
+                    "path_11_x": -13.619000434875488,
+                    "path_11_y": 0.0,
+                    "path_11_z": 12.234999656677246,
+                    "path_1_x": -9.418999671936035,
+                    "path_1_y": 0.0,
+                    "path_1_z": 13.034727096557617,
+                    "path_2_x": -8.519000053405762,
+                    "path_2_y": 0.0,
+                    "path_2_z": 12.4350004196167,
+                    "path_3_x": -7.818999767303467,
+                    "path_3_y": 0.0,
+                    "path_3_z": 11.335000038146973,
+                    "path_4_x": -7.718999862670898,
+                    "path_4_y": 0.0,
+                    "path_4_z": 6.434999942779541,
+                    "path_5_x": -8.319000244140625,
+                    "path_5_y": 0.0,
+                    "path_5_z": 5.434999942779541,
+                    "path_6_x": -9.519000053405762,
+                    "path_6_y": 0.0,
+                    "path_6_z": 4.434999942779541,
+                    "path_7_x": -11.218999862670898,
+                    "path_7_y": 0.0,
+                    "path_7_z": 3.934999942779541,
+                    "path_8_x": -12.119000434875488,
+                    "path_8_y": 0.0,
+                    "path_8_z": 4.434999942779541,
+                    "path_9_x": -12.718999862670898,
+                    "path_9_y": 0.0,
+                    "path_9_z": 5.534999847412109,
+                    "rotation_speed": 6.0,
+                    "speed": 1.6
+                },
+                "component_name": "EnemyPath"
             }
         ],
         "entity": 5,
-        "signature": "00000000000000000000000011000011"
+        "signature": "00000000000000100000000011000011"
     },
     {
         "components": [
@@ -1862,17 +1905,6 @@
         "components": [
             {
                 "component_data": {
-                    "color": {
-                        "b": 0.0,
-                        "g": 0.0,
-                        "r": 5000.0
-                    },
-                    "type": 0
-                },
-                "component_name": "Light"
-            },
-            {
-                "component_data": {
                     "orientation": {
                         "w": 1.0,
                         "x": 0.0,
@@ -1897,6 +1929,17 @@
                     "parent": 42
                 },
                 "component_name": "Parent"
+            },
+            {
+                "component_data": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 5000.0
+                    },
+                    "type": 0
+                },
+                "component_name": "Light"
             }
         ],
         "entity": 41,
@@ -1950,17 +1993,6 @@
         "components": [
             {
                 "component_data": {
-                    "color": {
-                        "b": 10000.0,
-                        "g": 10000.0,
-                        "r": 10000.0
-                    },
-                    "type": 0
-                },
-                "component_name": "Light"
-            },
-            {
-                "component_data": {
                     "orientation": {
                         "w": 1.0,
                         "x": 0.0,
@@ -1985,6 +2017,17 @@
                     "parent": 42
                 },
                 "component_name": "Parent"
+            },
+            {
+                "component_data": {
+                    "color": {
+                        "b": 10000.0,
+                        "g": 10000.0,
+                        "r": 10000.0
+                    },
+                    "type": 0
+                },
+                "component_name": "Light"
             }
         ],
         "entity": 43,
@@ -1992,17 +2035,6 @@
     },
     {
         "components": [
-            {
-                "component_data": {
-                    "color": {
-                        "b": 34.0,
-                        "g": 1000.0,
-                        "r": 115.0
-                    },
-                    "type": 0
-                },
-                "component_name": "Light"
-            },
             {
                 "component_data": {
                     "orientation": {
@@ -2029,6 +2061,17 @@
                     "parent": 42
                 },
                 "component_name": "Parent"
+            },
+            {
+                "component_data": {
+                    "color": {
+                        "b": 34.0,
+                        "g": 1000.0,
+                        "r": 115.0
+                    },
+                    "type": 0
+                },
+                "component_name": "Light"
             }
         ],
         "entity": 44,
@@ -2201,6 +2244,21 @@
         "components": [
             {
                 "component_data": {
+                    "center": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "range": {
+                        "x": 40.0,
+                        "y": 1.0,
+                        "z": 40.0
+                    }
+                },
+                "component_name": "ColliderAABB"
+            },
+            {
+                "component_data": {
                     "name": "Floor"
                 },
                 "component_name": "Name"
@@ -2241,21 +2299,6 @@
                     "layer_name": "default"
                 },
                 "component_name": "ColliderTag"
-            },
-            {
-                "component_data": {
-                    "center": {
-                        "x": 0.0,
-                        "y": 0.0,
-                        "z": 0.0
-                    },
-                    "range": {
-                        "x": 40.0,
-                        "y": 1.0,
-                        "z": 40.0
-                    }
-                },
-                "component_name": "ColliderAABB"
             }
         ],
         "entity": 48,
@@ -2310,6 +2353,21 @@
         "components": [
             {
                 "component_data": {
+                    "center": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "range": {
+                        "x": 25.0,
+                        "y": 6.0,
+                        "z": 1.0
+                    }
+                },
+                "component_name": "ColliderAABB"
+            },
+            {
+                "component_data": {
                     "name": "Left Wall"
                 },
                 "component_name": "Name"
@@ -2350,7 +2408,13 @@
                     "layer_name": "default"
                 },
                 "component_name": "ColliderTag"
-            },
+            }
+        ],
+        "entity": 50,
+        "signature": "00000000000000000010110000001011"
+    },
+    {
+        "components": [
             {
                 "component_data": {
                     "center": {
@@ -2359,19 +2423,13 @@
                         "z": 0.0
                     },
                     "range": {
-                        "x": 25.0,
+                        "x": 1.0,
                         "y": 6.0,
-                        "z": 1.0
+                        "z": 12.0
                     }
                 },
                 "component_name": "ColliderAABB"
-            }
-        ],
-        "entity": 50,
-        "signature": "00000000000000000010110000001011"
-    },
-    {
-        "components": [
+            },
             {
                 "component_data": {
                     "name": "Back Wall"
@@ -2414,21 +2472,6 @@
                     "layer_name": "default"
                 },
                 "component_name": "ColliderTag"
-            },
-            {
-                "component_data": {
-                    "center": {
-                        "x": 0.0,
-                        "y": 0.0,
-                        "z": 0.0
-                    },
-                    "range": {
-                        "x": 1.0,
-                        "y": 6.0,
-                        "z": 12.0
-                    }
-                },
-                "component_name": "ColliderAABB"
             }
         ],
         "entity": 51,
@@ -2514,6 +2557,37 @@
         "components": [
             {
                 "component_data": {
+                    "acceleration": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "mass": 1.0,
+                    "velocity": {
+                        "x": 0.0,
+                        "y": -1109.437744140625,
+                        "z": 0.0
+                    }
+                },
+                "component_name": "RigidBody"
+            },
+            {
+                "component_data": {
+                    "center": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    },
+                    "range": {
+                        "x": 0.5,
+                        "y": 0.5,
+                        "z": 0.5
+                    }
+                },
+                "component_name": "ColliderAABB"
+            },
+            {
+                "component_data": {
                     "orientation": {
                         "w": 0.6533471941947937,
                         "x": -0.6531223058700562,
@@ -2535,22 +2609,6 @@
             },
             {
                 "component_data": {
-                    "acceleration": {
-                        "x": 0.0,
-                        "y": 0.0,
-                        "z": 0.0
-                    },
-                    "mass": 1.0,
-                    "velocity": {
-                        "x": 0.0,
-                        "y": -1109.437744140625,
-                        "z": 0.0
-                    }
-                },
-                "component_name": "RigidBody"
-            },
-            {
-                "component_data": {
                     "material_type": 0,
                     "model_name": "items/planes/paint.mdl",
                     "scale_uv_with_transform": true
@@ -2562,21 +2620,6 @@
                     "layer_name": "default"
                 },
                 "component_name": "ColliderTag"
-            },
-            {
-                "component_data": {
-                    "center": {
-                        "x": 0.0,
-                        "y": 0.0,
-                        "z": 0.0
-                    },
-                    "range": {
-                        "x": 0.5,
-                        "y": 0.5,
-                        "z": 0.5
-                    }
-                },
-                "component_name": "ColliderAABB"
             }
         ],
         "entity": 53,


### PR DESCRIPTION
So far i have moving alongside path. Path can be defined in editor by adding the EnemyPath component and right clicking it to create/remove nodes. The entity will follow the path and look in the direction of the next node.

its simple, but i guess it will work untill we decide to either stick with this or use the robust navmesh lib