### PR TITLE
fix: bloom affects skybox

### DIFF
--- a/managers/render/common/framebuffer.cpp
+++ b/managers/render/common/framebuffer.cpp
@@ -307,3 +307,42 @@ void BloomBuffer::resize(uint32_t width, uint32_t height) {
 	}
 }
 
+void SkyboxBuffer::startup(uint32_t width, uint32_t height) {
+	glGenFramebuffers(1, &framebuffer_id);
+	glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_id);
+
+	// generate texture
+	glGenTextures(1, &texture_id);
+	glBindTexture(GL_TEXTURE_2D, texture_id);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, width, height, 0, GL_RGBA, GL_FLOAT, nullptr);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture_id, 0);
+
+	glDrawBuffer(GL_COLOR_ATTACHMENT0);
+
+	glGenRenderbuffers(1, &rbo_id);
+	glBindRenderbuffer(GL_RENDERBUFFER, rbo_id);
+	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, rbo_id);
+
+	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+		SPDLOG_ERROR("ERROR::FRAMEBUFFER:: Framebuffer is not complete!");
+	}
+
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void SkyboxBuffer::bind() {
+	glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_id);
+}
+
+void SkyboxBuffer::resize(uint32_t width, uint32_t height) {
+	glBindTexture(GL_TEXTURE_2D, texture_id);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, width, height, 0, GL_RGBA, GL_FLOAT, nullptr);
+
+	glBindRenderbuffer(GL_RENDERBUFFER, rbo_id);
+	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+}

--- a/managers/render/common/framebuffer.h
+++ b/managers/render/common/framebuffer.h
@@ -81,4 +81,15 @@ public:
 	void resize(uint32_t width, uint32_t height);
 };
 
+class SkyboxBuffer {
+public:
+    uint32_t framebuffer_id;
+    uint32_t texture_id;
+    uint32_t rbo_id;
+
+    void startup(uint32_t width, uint32_t height);
+    void bind();
+    void resize(uint32_t width, uint32_t height);
+};
+
 #endif // SILENCE_FRAMEBUFFER_H

--- a/managers/render/common/material.cpp
+++ b/managers/render/common/material.cpp
@@ -319,6 +319,7 @@ void MaterialCombination::bind_resources(RenderScene &scene) {
 	shader.set_int("SSAO", 3);
 	shader.set_int("AoRoughMetal", 4);
 	shader.set_int("ViewPos", 5);
+	shader.set_int("Skybox", 6);
 
 	shader.set_int("use_ao", cvar_use_ao.get());
 
@@ -338,6 +339,8 @@ void MaterialCombination::bind_resources(RenderScene &scene) {
 	glBindTexture(GL_TEXTURE_2D, scene.g_buffer.ao_rough_metal_texture_id);
 	glActiveTexture(GL_TEXTURE5);
 	glBindTexture(GL_TEXTURE_2D, scene.g_buffer.position_texture_id);
+	glActiveTexture(GL_TEXTURE6);
+	glBindTexture(GL_TEXTURE_2D, scene.skybox_buffer.texture_id);
 }
 
 void MaterialCombination::bind_instance_resources(ModelInstance &instance, Transform &transform) {

--- a/managers/render/common/render_pass.cpp
+++ b/managers/render/common/render_pass.cpp
@@ -70,7 +70,6 @@ void SkyboxPass::startup() {
 }
 
 void SkyboxPass::draw(RenderScene &scene) {
-	RenderManager &render_manager = RenderManager::get();
 	material.bind_resources(scene);
 	skybox.draw();
 }

--- a/managers/render/render_scene.cpp
+++ b/managers/render/render_scene.cpp
@@ -41,6 +41,7 @@ void RenderScene::startup() {
 	pbr_buffer.startup(render_extent.x, render_extent.y);
 	bloom_buffer.startup(render_extent.x, render_extent.y, 5);
 	combination_buffer.startup(render_extent.x, render_extent.y);
+	skybox_buffer.startup(render_extent.x, render_extent.y);
 
 	debug_draw.startup();
 	transparent_pass.startup();
@@ -122,11 +123,19 @@ void RenderScene::draw() {
 	// somehow see to match the default framebuffer's internal format with the FBO's internal format).
 	glBlitFramebuffer(0, 0, render_extent.x, render_extent.y, 0, 0, render_extent.x, render_extent.y,
 			GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+
+	skybox_buffer.bind();
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	glDepthFunc(GL_LEQUAL);
+	skybox_pass.draw(*this);
+	glDepthFunc(GL_LESS);
+
 	combination_buffer.bind();
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 	glDepthMask(GL_FALSE);
-	combination_pass.draw(*this); // CHECKED, this draws properly
+
+	combination_pass.draw(*this);
 
 	bloom_buffer.bind();
 	bloom_pass.draw(*this);
@@ -150,12 +159,6 @@ void RenderScene::draw() {
 	skinned_unlit_pass.draw(*this);
 #endif
 
-	if (true) {
-		glDepthFunc(GL_LEQUAL);
-		skybox_pass.draw(*this);
-		glDepthFunc(GL_LESS);
-	}
-
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	// ui needs to go last, later to be a different render target
@@ -171,6 +174,7 @@ void RenderScene::resize_framebuffer(uint32_t width, uint32_t height) {
 	pbr_buffer.resize(width, height);
 	bloom_buffer.resize(width, height);
 	combination_buffer.resize(width, height);
+	skybox_buffer.resize(width, height);
 
 	render_extent = glm::vec2(width, height);
 }

--- a/managers/render/render_scene.h
+++ b/managers/render/render_scene.h
@@ -43,6 +43,7 @@ struct RenderScene {
 	SSAOBuffer ssao_buffer;
 	CombinationBuffer combination_buffer;
 	BloomBuffer bloom_buffer;
+	SkyboxBuffer skybox_buffer;
 	glm::vec2 render_extent;
 
 	DebugDraw debug_draw;

--- a/resources/shaders/combination.frag
+++ b/resources/shaders/combination.frag
@@ -10,6 +10,7 @@ uniform sampler2D Specular;
 uniform sampler2D SSAO;
 uniform sampler2D AoRoughMetal;
 uniform sampler2D ViewPos;
+uniform sampler2D Skybox;
 
 uniform int use_fog;
 uniform float fog_min;
@@ -24,6 +25,15 @@ void main()
     vec3 specular = texture(Specular, TexCoords).rgb;
     float ssao = texture(SSAO, TexCoords).r;
     float ao = texture(AoRoughMetal, TexCoords).r;
+    vec3 skybox = texture(Skybox, TexCoords).rgb;
+    vec4 view_pos = texture(ViewPos, TexCoords);
+
+    if (
+    albedo == vec3(0.0, 0.0, 0.0) && diffuse == vec3(0.0, 0.0, 0.0) && view_pos.xyz == vec3(0.0, 0.0, 0.0)
+    ) {
+        FragColor = vec4(skybox, 1.0);
+        return;
+    }
 
     float final_ao = min(ssao, ao);
     if (!use_ao) {
@@ -34,7 +44,7 @@ void main()
     // color = specular;
 
     if (use_fog == 1) {
-        vec4 view_pos = texture(ViewPos, TexCoords);
+        vec4 view_pos = view_pos;
         float distance = distance(vec3(0.0, 0.0, 0.0), view_pos.xyz);
         float fog_value = clamp((distance - fog_min) / fog_max, 0.0, 1.0);
 

--- a/resources/shaders/skybox.frag
+++ b/resources/shaders/skybox.frag
@@ -1,5 +1,6 @@
 #version 330 core
 out vec4 FragColor;
+
 in vec3 WorldPos;
 
 uniform samplerCube environment_map;


### PR DESCRIPTION
Rendering skybox to a separate framebuffer, then in `combination_pass` it is blended where nothing else is, although I'm pretty sure there's a better way of doing this rather than placing it where all other input textures are zeroed. (in `combination.frag`)