### PR TITLE
feat: raycasting now has range

### DIFF
--- a/managers/ecs/systems/agent_system.cpp
+++ b/managers/ecs/systems/agent_system.cpp
@@ -305,6 +305,7 @@ void AgentSystem::update(World &world, float dt) {
 								ray.ignore_list.emplace_back(entity);
 								ray.origin = sphere.center;
 								ray.direction = transform.get_global_position() - sphere.center;
+								ray.length = 3.0f;
 								HitInfo info;
 								glm::vec3 end = ray.origin + ray.direction;
 								dd.draw_arrow(ray.origin, end, { 1.0f, 0.0f, 0.0f });
@@ -355,6 +356,7 @@ void AgentSystem::update(World &world, float dt) {
 			ray.direction = model_tf.get_forward();
 			ray.origin = transform.get_global_position() + glm::vec3(0.0f, 1.0f, 0.0f);
 			ray.ignore_list.emplace_back(entity);
+			ray.length = 3.0f;
 
 			end = ray.origin + ray.direction;
 			world.get_parent_scene()->get_render_scene().debug_draw.draw_arrow(ray.origin, end, { 255, 0, 0 });

--- a/managers/physics/ecs/collision_system.cpp
+++ b/managers/physics/ecs/collision_system.cpp
@@ -571,6 +571,12 @@ bool CollisionSystem::ray_cast(World &world, const Ray &ray, HitInfo &result) {
 			continue;
 		}
 
+		// check how far the entity is from the ray origin and if it is outside of range, ignore it
+		const Transform &transform = world.get_component<Transform>(entity);
+		if (glm::distance(transform.get_global_position(), ray.origin) > ray.length) {
+			continue;
+		}
+
 		if (!world.has_component<ColliderTag>(entity) || !world.has_component<Transform>(entity)) {
 			continue;
 		}
@@ -581,7 +587,6 @@ bool CollisionSystem::ray_cast(World &world, const Ray &ray, HitInfo &result) {
 			continue;
 		}
 
-		const Transform &transform = world.get_component<Transform>(entity);
 		const glm::vec3 &position = transform.get_global_position();
 		const glm::vec3 &scale = transform.get_global_scale();
 		HitInfo info;
@@ -634,6 +639,12 @@ bool CollisionSystem::ray_cast_layer(World &world, const Ray &ray, HitInfo &resu
 			continue;
 		}
 
+		// check how far the entity is from the ray origin and if it is outside of range, ignore it
+		const Transform &transform = world.get_component<Transform>(entity);
+		if (glm::distance(transform.get_global_position(), ray.origin) > ray.length) {
+			continue;
+		}
+
 		if (std::find(ray.ignore_list.begin(), ray.ignore_list.end(), entity) != ray.ignore_list.end()) {
 			continue;
 		}
@@ -647,9 +658,10 @@ bool CollisionSystem::ray_cast_layer(World &world, const Ray &ray, HitInfo &resu
 		if (!physics_manager.are_layers_collide(ray.layer_name, tag.layer_name)) {
 			continue;
 		}
-		const Transform &transform = world.get_component<Transform>(entity);
+
 		const glm::vec3 &position = transform.get_global_position();
 		const glm::vec3 &scale = transform.get_global_scale();
+
 		HitInfo info;
 		info.entity = entity;
 		if (world.has_component<ColliderAABB>(entity)) {

--- a/managers/physics/physics_manager.h
+++ b/managers/physics/physics_manager.h
@@ -13,6 +13,7 @@ struct ColliderTag;
 struct Ray {
 	glm::vec3 origin;
 	glm::vec3 direction;
+	float length = std::numeric_limits<float>::max();
 	std::string layer_name = "default";
 	std::vector<std::string> ignore_layers;
 	std::vector<Entity> ignore_list;


### PR DESCRIPTION
raycast checks if an entity is in range given by `Ray.lenght`, before checking anything else like components and stuff. This can optimize all the short range raycasts like all interaction rayasts of a player